### PR TITLE
Update @shopify/ui-extensions version in package.json

### DIFF
--- a/extensions/customize-footer/package.json
+++ b/extensions/customize-footer/package.json
@@ -6,6 +6,6 @@
   "dependencies": {
     "preact": "^10.10.x",
     "@preact/signals": "^2.3.x",
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "~2025.10.0"
   }
 }


### PR DESCRIPTION
Fix versioning that it is causing a conflict not allowing the app to run. Error:

─ error ───────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                   │
│  Type reference for purchase.checkout.footer.render-after could not be found. You might be using  │
│   the wrong @shopify/ui-extensions version.                                                       │
│                                                                                                   │
│  Fix the error by ensuring you have the correct version of @shopify/ui-extensions, for example    │
│  2025.10.0, in your dependencies.